### PR TITLE
Connect to admin container by default with `firehpc ssh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to
   - Move `maxtime` and `state` Slurm partitions parameters in `params`
     sub-dictionary.
   - Rename `slurm_partitions` > `node`→`nodes` key.
+- docs: Explain in manpage ssh command considers admin container by default.
 
 ### Fixed
 - core:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to
 ### Changed
 - Transform `fhpc_nodes` dictionary values from list of nodes to list of
   dictionaries to group nodes by type in RacksDB.
+- `firehpc ssh <cluster>` now connects to _admin_ host by default (#8).
 - usage emulator: Change pending jobs limit formula to avoid number of jobs
   growing as fast as the number of nodes.
 - conf:

--- a/docs/man/firehpc.adoc
+++ b/docs/man/firehpc.adoc
@@ -171,10 +171,11 @@ This command accepts the following options:
 +
 --
 This command requires at least one argument to specify the destination container
-in the format [LOGIN@]CONTAINER.CLUSTER (ex: `admin.hpc` or `john@login.hpc`).
-Additional arguments are treated as a command to execute on container with its
-own arguments. Without additional arguments, an interactive shell is launched in
-the container.
+in the format [LOGIN@][CONTAINER.]CLUSTER (ex: `hpc`, `login.hpc`, `root@hpc` or
+`john@cn1.hpc`). By default, _admin_ container is considered. Additional
+arguments are treated as a command to execute on container with its own
+arguments. Without additional arguments, an interactive shell is launched in the
+container.
 --
 
 [.cli-opt]#*start*#::

--- a/firehpc/exec.py
+++ b/firehpc/exec.py
@@ -295,13 +295,9 @@ class FireHPCExec:
         cluster.stop()
 
     def _execute_ssh(self):
-        if "." not in self.args.args[0]:
-            logger.critical(
-                "Format of ssh command first argument is not valid, it must be "
-                "destination node with format: [login@]node.cluster"
-            )
-            sys.exit(1)
-        cluster_name = self.args.args[0].split(".")[1]
+        cluster_name = self.args.args[0]
+        if "." in self.args.args[0]:
+            cluster_name = cluster_name.split(".")[1]
         cluster = EmulatedCluster(self.settings, cluster_name, self.args.state)
         ssh = SSHClient(cluster)
         ssh.exec(self.args.args)

--- a/firehpc/ssh.py
+++ b/firehpc/ssh.py
@@ -51,6 +51,10 @@ class SSHClient:
             # connect with root user by default
             username = "root"
             hostname = args[0]
+        # When dot is absent from hostname, consider it is the cluster name. In this
+        # case, connect to admin host of this cluster by default.
+        if "." not in hostname:
+            hostname  = "admin." + hostname
         # append container namespace to hostname
         hostname += f".{ContainersManager(self.cluster).namespace}"
         if self.asbin:


### PR DESCRIPTION
fix #8