### PR TITLE
feat(conf): support slurm native auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to
     configuration extracted from RacksDB.
   - Add `params` key in `slurm_partitions` parameter to give possibility to
     set any arbitrary Slurm partition configuration parameter in inventory.
+  - Support Slurm native authentication in alternative to munge (#22).
 - docs:
   - Add sysctl `fs.inotify.max_user_instances` value increase recommendation in
     README.md to avoid weird issue when launching many containers.
@@ -63,6 +64,8 @@ and this project adheres to
   - Move `maxtime` and `state` Slurm partitions parameters in `params`
     sub-dictionary.
   - Rename `slurm_partitions` > `node`→`nodes` key.
+  - Change default Slurm authentication plugin from munge to slurm. This can be
+    changed by setting `slurm_with_munge: true` in Ansible inventory.
 - docs: Explain in manpage ssh command considers admin container by default.
 
 ### Fixed

--- a/conf/group_vars/all.yml
+++ b/conf/group_vars/all.yml
@@ -32,7 +32,9 @@ slurm_server: "{{ groups['admin'][0] }}"
 slurm_profiles:
   compute: compute
   server: admin
+  login: login
 slurm_local_munge_key_file: "{{ fhpc_cluster_state_dir }}/munge/munge.key"
+slurm_local_slurm_key_file: "{{ fhpc_cluster_state_dir }}/slurm/slurm.key"
 slurm_local_mariadb_password_file: "{{ fhpc_cluster_state_dir }}/mariadb/mariadb.password"
 slurm_local_jwt_key_file: "{{ fhpc_cluster_state_dir }}/slurm/jwt_hs256.key"
 slurm_users: "{{ fhpc_users | map(attribute='login') | list }}"

--- a/conf/roles/slurm/defaults/main.yml
+++ b/conf/roles/slurm/defaults/main.yml
@@ -1,11 +1,13 @@
 ---
 slurm_profiles: {}
 slurm_emulator: False
+slurm_with_munge: false
 slurm_uid: 432  # picked randomly among 100-499
 slurm_gid: 432  # picked randomly among 100-499
 slurm_server: admin
 slurm_cluster: hpc
 slurm_local_munge_key_file: munge.key  # dummy
+slurm_local_slurm_key_file: slurm.key  # dummy
 slurm_local_mariadb_password_file: mariadb.password  # dummy
 slurm_local_jwt_key_file: jwt_hs256.key  # dummy
 # The lookup errors are ignored because the variable is loaded by boostrap

--- a/conf/roles/slurm/handlers/main.yml
+++ b/conf/roles/slurm/handlers/main.yml
@@ -31,3 +31,12 @@
   ansible.builtin.service:
     name: munge
     state: restarted
+  when: slurm_with_munge
+
+- name: Restart sackd
+  ansible.builtin.service:
+    name: sackd
+    state: restarted
+  when:
+  - not slurm_with_munge
+  - slurm_profiles['login'] in group_names

--- a/conf/roles/slurm/tasks/bootstrap.yml
+++ b/conf/roles/slurm/tasks/bootstrap.yml
@@ -4,11 +4,26 @@
     path: "{{ slurm_local_munge_key_file | dirname }}"
     state: directory
     recurse: true
+  when: slurm_with_munge
 
 - name: Generate munge key
   ansible.builtin.command:
     cmd: "dd if=/dev/urandom of={{ slurm_local_munge_key_file }} bs=1 count=1024"
     creates: "{{ slurm_local_munge_key_file }}"
+  when: slurm_with_munge
+
+- name: Create local slurm directory
+  ansible.builtin.file:
+    path: "{{ slurm_local_jwt_key_file | dirname }}"
+    state: directory
+    recurse: true
+  when: (slurm_with_slurmrestd and slurm_with_jwt) or not slurm_with_munge
+
+- name: Generate slurm key
+  ansible.builtin.command:
+    cmd: "dd if=/dev/urandom of={{ slurm_local_slurm_key_file }} bs=1 count=1024"
+    creates: "{{ slurm_local_slurm_key_file }}"
+  when: not slurm_with_munge
 
 - name: Create local mariadb directory
   ansible.builtin.file:
@@ -21,15 +36,6 @@
     content: "{{ lookup('community.general.random_string', length=16, special=false) }}" # avoid special character that may confuse either slurmdbd or mariadb
     dest: "{{ slurm_local_mariadb_password_file }}"
     force: no  # do not overwrite the password if it has already been generated
-
-- name: Create local slurm directory
-  ansible.builtin.file:
-    path: "{{ slurm_local_jwt_key_file | dirname }}"
-    state: directory
-    recurse: true
-  when:
-  - slurm_with_slurmrestd
-  - slurm_with_jwt
 
 - name: Generate slurm JWT signing key
   ansible.builtin.command:

--- a/conf/roles/slurm/tasks/login.yml
+++ b/conf/roles/slurm/tasks/login.yml
@@ -1,0 +1,14 @@
+---
+- name: Install sackd packages
+  ansible.builtin.package:
+    name: "{{ slurm_sackd_packages }}"
+    state: latest
+  when: not slurm_with_munge
+
+# This is required on redhat based distributions as the service is not
+# automatically started by the RPM packages, and it does not hurt on Debian.
+- name: Ensure sackd service is started
+  ansible.builtin.service:
+    name: sackd
+    state: started
+    enabled: yes

--- a/conf/roles/slurm/tasks/main.yml
+++ b/conf/roles/slurm/tasks/main.yml
@@ -27,6 +27,12 @@
     name: "{{ slurm_emulator | ternary(slurm_emulator_common_packages, slurm_common_packages) }}"
     state: latest
 
+- name: Install munge packages
+  ansible.builtin.package:
+    name: "{{ slurm_munge_packages }}"
+    state: latest
+  when: slurm_with_munge
+
 - name: Create slurm configuration directory
   ansible.builtin.file:
     path: /etc/slurm
@@ -54,6 +60,21 @@
     group: munge
     mode: '0400'
   notify: Restart munge
+  when: slurm_with_munge
+
+- name: Deploy slurm key
+  ansible.builtin.copy:
+    src: "{{ slurm_local_slurm_key_file }}"
+    dest: /etc/slurm/slurm.key
+    owner: slurm
+    group: slurm
+    mode: '0400'
+  notify:
+  - Restart slurmctld
+  - Restart slurmdbd
+  - Restart slurmd
+  - Restart sackd
+  when: not slurm_with_munge
 
 # This is required on redhat based distributions as the service is not
 # automatically started by the RPM packages, and it does not hurt on Debian.
@@ -62,6 +83,7 @@
     name: munge
     state: started
     enabled: yes
+  when: slurm_with_munge
 
 # Each profile is applied in the group associated the keys or slurm_profiles
 # hash or all the profiles are applied on the unique server node when

--- a/conf/roles/slurm/templates/slurm.conf.j2
+++ b/conf/roles/slurm/templates/slurm.conf.j2
@@ -7,6 +7,13 @@ SlurmdParameters=config_overrides                 # default: none
 SlurmUser=slurm                                   # default: root
 StateSaveLocation={{ slurm_state_save_loc }}      # default: /var/spool
 SlurmdSpoolDir={{ slurm_slurmd_spool_dir }}       # default: /var/spool/slurmd
+{% if slurm_with_munge %}
+AuthType = auth/munge
+CredType = cred/munge
+{% else %}
+AuthType = auth/slurm
+CredType = cred/slurm
+{% endif %}
 AccountingStorageType=accounting_storage/slurmdbd # default: accounting_storage/none
 AccountingStorageHost={{ slurm_server }}          # must be specified, as soon as slurmdbd is used
 AccountingStorageEnforce=qos,limits,associations  # default: none

--- a/conf/roles/slurm/templates/slurmdbd.conf.j2
+++ b/conf/roles/slurm/templates/slurmdbd.conf.j2
@@ -3,6 +3,11 @@ SlurmUser=slurm                      # default: root
 StorageType=accounting_storage/mysql # must be specified
 StoragePass={{ slurm_db_password }}  # must be specified
 StorageUser=slurm                    # must be specified
+{% if slurm_with_munge %}
+AuthType = auth/munge
+{% else %}
+AuthType = auth/slurm
+{% endif %}
 {% if slurm_with_jwt %}
 AuthAltTypes=auth/jwt
 AuthAltParameters=jwt_key={{ slurm_jwt_key_path }}

--- a/conf/roles/slurm/vars/os/debian.yml
+++ b/conf/roles/slurm/vars/os/debian.yml
@@ -1,7 +1,6 @@
 ---
 slurm_common_packages:
   - slurm-client
-  - munge
 slurm_server_packages:
   - slurmctld
   - slurmdbd
@@ -11,7 +10,10 @@ slurm_compute_packages:
   - slurmd
 slurm_emulator_common_packages:
   - slurm-emulator
+slurm_munge_packages:
   - munge
+slurm_sackd_packages:
+  - sackd
 slurm_emulator_server_packages: []
 slurm_emulator_compute_packages: []
 slurm_state_save_loc: /var/lib/slurm/slurmctld

--- a/conf/roles/slurm/vars/os/redhat.yml
+++ b/conf/roles/slurm/vars/os/redhat.yml
@@ -1,7 +1,6 @@
 ---
 slurm_common_packages:
   - slurm
-  - munge
 slurm_server_packages:
   - slurm-slurmctld
   - slurm-slurmdbd
@@ -9,6 +8,10 @@ slurm_restd_packages:
   - slurm-slurmrestd
 slurm_compute_packages:
   - slurm-slurmd
+slurm_munge_packages:
+  - munge
+slurm_sackd_packages:
+  - slurm-sackd
 slurm_state_save_loc: /var/spool/slurm/ctld
 slurm_slurmd_spool_dir: /var/spool/slurm/d
 slurm_jwt_key_path: /var/spool/slurm/jwt_hs256.key


### PR DESCRIPTION
Suport Slurm native/internal authentication plugin (aka. sackd) in alternative to munge. This is also the new default in FireHPC. Munge authentication can be reverted back with slurm_with_munge: true in custom inventory.

fix #22