### PR TITLE
feat(conf): slurm GPU acct storage by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 - conf:
   - Add pkgs.rackslab.io packages repositories by default.
   - Support GPU gres without model in Slurm configuration.
+  - Set `AccountingStorageTRES` for GPU GRES when Slurm accounting is enabled
+    and the cluster defines GPUs.
   - Add SSL/TLS certificate for Slurm-web with internal CA.
   - Support serving Slurm-web gateway in HTTP server subfolder.
   - Add support of slurm-quota (#52).

--- a/conf/roles/slurm/templates/slurm.conf.j2
+++ b/conf/roles/slurm/templates/slurm.conf.j2
@@ -18,6 +18,18 @@ CredType = cred/slurm
 AccountingStorageType=accounting_storage/slurmdbd # default: accounting_storage/none
 AccountingStorageHost={{ slurm_server }}          # must be specified, as soon as slurmdbd is used
 AccountingStorageEnforce=qos,limits,associations  # default: none
+{% if slurm_with_gres_gpu and 'AccountingStorageTRES' not in slurm_params %}
+{% set gpu_tres = ['gres/gpu'] %}
+{% for node_type in slurm_compute_nodes %}
+{% for model in node_type.gpus %}
+{% set has_model = (model in slurm_gpus_models_map and slurm_gpus_models_map.get(model) is not none) %}
+{% if has_model %}
+{% set _ = gpu_tres.append('gres/gpu:' ~ slurm_gpus_models_map.get(model, 'nvidia')) %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+AccountingStorageTRES={{ gpu_tres | unique | sort | join(',') }}
+{% endif %}
 {% endif %}
 {% if slurm_with_jwt %}
 AuthAltTypes=auth/jwt


### PR DESCRIPTION
Automatically enable AccountStorageTRES for all gpus in Slurm.